### PR TITLE
MOBCOOK-4557:  Add package.json, so NPM can install it from Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "open-fb",
+  "version": "0.0.5-cs",
+  "repository": "ChefSteps/OpenFB",
+  "main": "dist/openfb.min.js",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-release": "^0.11.0",
+    "grunt-shell": "^1.1.2"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
In order for us to use this lib via NPM, it needs a `package.json`.  This one is an edited version of the one in https://github.com/ccoenraets/OpenFB/pull/56/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2.
